### PR TITLE
Timeout Vibrate Toggle

### DIFF
--- a/src/c/settings_window.c
+++ b/src/c/settings_window.c
@@ -7,7 +7,8 @@
 #define MENU_SECTION_MAIN 0
 #define MENU_ROW_PIN_ACTION 0
 #define MENU_ROW_STATUSBAR_TOGGLE 1
-#define MENU_ROW_SYSTEM_INFO 2
+#define MENU_ROW_TOVIBRATE_TOGGLE 2
+#define MENU_ROW_SYSTEM_INFO 3
 
 typedef enum {
   PIN_MODE_NONE,
@@ -119,7 +120,7 @@ static uint16_t prv_menu_get_num_sections_callback(MenuLayer *menu_layer, void *
 }
 
 static uint16_t prv_menu_get_num_rows_callback(MenuLayer *menu_layer, uint16_t section_index, void *data) {
-  return 3;  // PIN action, Status Bar toggle, System Info
+  return 4;  // PIN action, Status Bar toggle, Timeout Vibrate toggle, System Info
 }
 
 static int16_t prv_menu_get_header_height_callback(MenuLayer *menu_layer, uint16_t section_index, void *data) {
@@ -133,6 +134,7 @@ static void prv_menu_draw_header_callback(GContext* ctx, const Layer *cell_layer
 static void prv_menu_draw_row_callback(GContext* ctx, const Layer *cell_layer, MenuIndex *cell_index, void *data) {
   bool has_pin = storage_has_pin();
   bool statusbar_enabled = storage_is_statusbar_enabled();
+  bool tovibrate_enabled = storage_is_tovibrate_enabled();
   
   switch (cell_index->row) {
     case MENU_ROW_PIN_ACTION:
@@ -146,6 +148,11 @@ static void prv_menu_draw_row_callback(GContext* ctx, const Layer *cell_layer, M
     case MENU_ROW_STATUSBAR_TOGGLE:
       menu_cell_basic_draw(ctx, cell_layer, "Status Bar", 
                           statusbar_enabled ? "Enabled" : "Disabled", NULL);
+      break;
+
+    case MENU_ROW_TOVIBRATE_TOGGLE:
+      menu_cell_basic_draw(ctx, cell_layer, "Timeout Vibrate", 
+                          tovibrate_enabled ? "Enabled" : "Disabled", NULL);
       break;
       
     case MENU_ROW_SYSTEM_INFO:
@@ -186,11 +193,11 @@ static void prv_menu_select_callback(MenuLayer *menu_layer, MenuIndex *cell_inde
       }
       break;
       
-    case MENU_ROW_STATUSBAR_TOGGLE:
-      // Toggle status bar setting
+    case MENU_ROW_TOVIBRATE_TOGGLE:
+      // Toggle vibrate timeout setting
       {
-        bool current = storage_is_statusbar_enabled();
-        storage_set_statusbar_enabled(!current);
+        bool current = storage_is_tovibrate_enabled();
+        storage_set_tovibrate_enabled(!current);
         
         // Reload menu to show new status
         menu_layer_reload_data(menu_layer);
@@ -201,6 +208,22 @@ static void prv_menu_select_callback(MenuLayer *menu_layer, MenuIndex *cell_inde
         vibes_short_pulse();
       }
       break;
+
+    case MENU_ROW_STATUSBAR_TOGGLE:
+    // Toggle status bar setting
+    {
+      bool current = storage_is_statusbar_enabled();
+      storage_set_statusbar_enabled(!current);
+      
+      // Reload menu to show new status
+      menu_layer_reload_data(menu_layer);
+      
+      // Reload main window to apply changes
+      ui_reload_window();
+      
+      vibes_short_pulse();
+    }
+    break;
       
     case MENU_ROW_SYSTEM_INFO:
       // Create and show system info window

--- a/src/c/storage.c
+++ b/src/c/storage.c
@@ -226,3 +226,18 @@ void storage_set_statusbar_enabled(bool enabled) {
   persist_write_bool(PERSIST_KEY_STATUSBAR_ENABLED, enabled);
 }
 
+// ============================================================================
+// Timeout Vibrate managment
+// ============================================================================
+
+bool storage_is_tovibrate_enabled(void) {
+  if (!persist_exists(PERSIST_KEY_TOVIBRATE_ENABLED)) {
+    return true;  // Default: enabled
+  }
+  return (bool)persist_read_bool(PERSIST_KEY_TOVIBRATE_ENABLED);
+}
+
+void storage_set_tovibrate_enabled(bool enabled) {
+  persist_write_bool(PERSIST_KEY_TOVIBRATE_ENABLED, enabled);
+}
+

--- a/src/c/storage.h
+++ b/src/c/storage.h
@@ -5,6 +5,7 @@
 #define PERSIST_KEY_COUNT 0
 #define PERSIST_KEY_PIN_HASH 2
 #define PERSIST_KEY_STATUSBAR_ENABLED 3
+#define PERSIST_KEY_TOVIBRATE_ENABLED 4
 #define PERSIST_KEY_ACCOUNTS_START 8
 
 // Get account count
@@ -36,3 +37,6 @@ void storage_clear_pin(void);
 bool storage_is_statusbar_enabled(void);
 void storage_set_statusbar_enabled(bool enabled);
 
+// Timeout Vibrate managment
+bool storage_is_tovibrate_enabled(void);
+void storage_set_tovibrate_enabled(bool enabled);

--- a/src/c/ui.c
+++ b/src/c/ui.c
@@ -188,6 +188,9 @@ void ui_update_codes(void) {
   time_t now = time(NULL);
   bool needs_redraw = false;
   bool needs_vibe = false;
+
+  // Timeout Vibrate if enabled
+  bool tovibrate_enabled = storage_is_tovibrate_enabled();
   
   for (size_t i = 0; i < s_total_account_count; i++) {
     AccountCache *cache = &s_account_cache[i];
@@ -219,7 +222,7 @@ void ui_update_codes(void) {
     layer_mark_dirty(menu_layer_get_layer(s_menu_layer));
   }
 
-  if (needs_vibe) {
+  if (tovibrate_enabled && needs_vibe) {
     uint32_t const segments[] = { 50 };
     VibePattern pat = {
       .durations = segments,


### PR DESCRIPTION
Hi there,

I like this app quite a bit, I feel it's the most fully featured authenticator app on Pebble. Thank you for making it! 

In my time using it, there is one thing that has bothered me. I often keep this app open on my watch for an extended period of time. Some accounts lock me out quickly, and having the TOTP on my wrist is far easier than pulling out my phone. However, having the three pulses every time the code is about to timeout becomes annoying after a few minutes. Since I saw it was open source, I figured I'd add a toggle myself.

# Changes
The changes boil down to adding a "Timeout Vibrate" option in the settings, adding an associated storage variable and adding a check for it in the vibration code. See the change log for exact additions. Most of it was done by copying exact what was used for the Status Bar toggle and just changing it for my needs.

# Notes
I put the toggle below the Status Bar toggle, though it can go anywhere if you that position doesn't work for whatever reason. I also noted that the persistent storage keys 4-7 were unused, so I made the key for this 4. If those keys were reserved for some other purpose, that can be changed easily as well.

Other than that, pretty simple addition that helps a lot in my use case and just adds a little more customizability. Let me know if you need me to make any changes, and thank you for considering this request.